### PR TITLE
fix: Fixed the error where the front-end page still showed "not configured" after setting up TIANAPI.

### DIFF
--- a/server/routes/exchangeRates.js
+++ b/server/routes/exchangeRates.js
@@ -20,6 +20,15 @@ function createExchangeRateRoutes(db) {
     // GET exchange rate statistics (Public)
     router.get('/stats', controller.getExchangeRateStats);
 
+    // GET exchange rate configuration status (Public)
+    router.get('/config-status', (req, res) => {
+        res.json({
+            tianApiConfigured: !!process.env.TIANAPI_KEY,
+            provider: 'tianapi.com',
+            updateFrequency: 'Daily (Automatic)'
+        });
+    });
+
     return router;
 }
 

--- a/src/components/ExchangeRateManager.tsx
+++ b/src/components/ExchangeRateManager.tsx
@@ -16,6 +16,7 @@ export function ExchangeRateManager() {
     exchangeRates,
     lastExchangeRateUpdate,
     apiKey,
+    exchangeRateConfigStatus,
     fetchExchangeRates,
     updateExchangeRatesFromApi,
     currency,
@@ -129,7 +130,7 @@ export function ExchangeRateManager() {
                 <div className="space-y-1">
                   <p className="text-sm font-medium">API Configuration</p>
                   <div className="flex items-center gap-2">
-                    {apiKey ? (
+                    {exchangeRateConfigStatus?.tianApiConfigured ? (
                       <>
                         <CheckCircle className="h-4 w-4 text-green-500" />
                         <span className="text-sm text-green-600">Configured</span>
@@ -160,7 +161,7 @@ export function ExchangeRateManager() {
 
 
 
-              {!apiKey && (
+              {!exchangeRateConfigStatus?.tianApiConfigured && (
                 <div className="flex items-center gap-2 p-3 bg-yellow-50 border border-yellow-200 rounded-md">
                   <AlertCircle className="h-4 w-4 text-yellow-600" />
                   <p className="text-sm text-yellow-800">
@@ -173,7 +174,7 @@ export function ExchangeRateManager() {
             <div className="flex gap-2 mt-4">
               <Button
                 onClick={handleUpdateRates}
-                disabled={isUpdating || !apiKey}
+                disabled={isUpdating || !exchangeRateConfigStatus?.tianApiConfigured || !apiKey}
                 size="sm"
               >
                 {isUpdating ? (

--- a/src/services/exchangeRateApi.ts
+++ b/src/services/exchangeRateApi.ts
@@ -17,6 +17,12 @@ export interface ExchangeRateStatus {
   hasApiKey: boolean;
 }
 
+export interface ExchangeRateConfigStatus {
+  tianApiConfigured: boolean;
+  provider: string;
+  updateFrequency: string;
+}
+
 /**
  * 汇率 API 服务
  */
@@ -65,6 +71,18 @@ export class ExchangeRateApi {
       return await apiClient.get<ExchangeRateStatus>('/exchange-rates/status');
     } catch (error) {
       logger.error('Error fetching scheduler status:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * 获取汇率配置状态
+   */
+  static async getConfigStatus(): Promise<ExchangeRateConfigStatus> {
+    try {
+      return await apiClient.get<ExchangeRateConfigStatus>('/exchange-rates/config-status');
+    } catch (error) {
+      logger.error('Error fetching config status:', error);
       throw error;
     }
   }


### PR DESCRIPTION
Fixed the error where the front-end page still showed "not configured" after setting up TIANAPI.

<img width="1374" height="726" alt="image" src="https://github.com/user-attachments/assets/45c762a7-60e7-46c2-a5de-74371738ace1" />

After the fix, TIANAPI status can be displayed normally.

<img width="1376" height="598" alt="image" src="https://github.com/user-attachments/assets/454c3edb-86b5-4ac4-a0f8-f48a4c63f0f8" />
