### PR TITLE
Synchronize base currency settings and fix subscription default

### DIFF
--- a/server/routes/exchangeRates.js
+++ b/server/routes/exchangeRates.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const ExchangeRateController = require('../controllers/exchangeRateController');
+const { getBaseCurrency } = require('../config/currencies');
 
 function createExchangeRateRoutes(db) {
     const router = express.Router();
@@ -25,7 +26,8 @@ function createExchangeRateRoutes(db) {
         res.json({
             tianApiConfigured: !!process.env.TIANAPI_KEY,
             provider: 'tianapi.com',
-            updateFrequency: 'Daily (Automatic)'
+            updateFrequency: 'Daily (Automatic)',
+            baseCurrency: getBaseCurrency()
         });
     });
 

--- a/src/components/subscription/PaymentHistorySheet.tsx
+++ b/src/components/subscription/PaymentHistorySheet.tsx
@@ -25,7 +25,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { DatePicker } from "@/components/ui/date-picker"
 import { CurrencySelector } from "@/components/subscription/CurrencySelector"
 import { PaymentRecord } from "@/utils/dataTransform"
-import { getBaseCurrency } from "@/config/currency"
+import { useSettingsStore } from "@/store/settingsStore"
 
 // Form data type for payment record (internal use with Date objects)
 interface PaymentFormData {
@@ -75,13 +75,14 @@ export function PaymentHistorySheet({
 }: PaymentHistorySheetProps) {
   const { t } = useTranslation(['common', 'validation'])
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const { currency: userCurrency } = useSettingsStore()
 
   // State for form data and validation errors
   const [form, setForm] = useState<PaymentFormData>({
     subscriptionId,
     paymentDate: new Date(),
     amountPaid: 0,
-    currency: getBaseCurrency(),
+    currency: userCurrency,
     billingPeriodStart: new Date(),
     billingPeriodEnd: new Date(),
     status: "succeeded",
@@ -109,7 +110,7 @@ export function PaymentHistorySheet({
         subscriptionId,
         paymentDate: new Date(),
         amountPaid: 0,
-        currency: getBaseCurrency(),
+        currency: userCurrency,
         billingPeriodStart: new Date(),
         billingPeriodEnd: new Date(),
         status: "succeeded",
@@ -117,7 +118,7 @@ export function PaymentHistorySheet({
       })
     }
     setErrors({})
-  }, [initialData, subscriptionId, open])
+  }, [initialData, subscriptionId, open, userCurrency])
 
   // Validation function
   const validateForm = (): boolean => {

--- a/src/components/subscription/SubscriptionForm.tsx
+++ b/src/components/subscription/SubscriptionForm.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react"
 import { format } from "date-fns"
-import { getBaseCurrency } from '@/config/currency'
+import { useSettingsStore } from '@/store/settingsStore'
 import { useTranslation } from "react-i18next"
 
 import { Button } from "@/components/ui/button"
@@ -51,6 +51,7 @@ export function SubscriptionForm({
     categories,
     paymentMethods
   } = useSubscriptionStore()
+  const { currency: userCurrency } = useSettingsStore()
   
   const { t } = useTranslation(['common', 'subscription', 'validation'])
 
@@ -60,7 +61,7 @@ export function SubscriptionForm({
     plan: "",
     billingCycle: "monthly",
     amount: 0,
-    currency: getBaseCurrency(),
+    currency: userCurrency,
     paymentMethodId: 0,
     startDate: format(new Date(), "yyyy-MM-dd"),
     nextBillingDate: calculateNextBillingDateFromStart(new Date(), new Date(), "monthly"),
@@ -98,7 +99,7 @@ export function SubscriptionForm({
           plan: "",
           billingCycle: "monthly",
           amount: 0,
-          currency: "USD",
+          currency: userCurrency,
           paymentMethodId: 0,
           startDate: format(new Date(), "yyyy-MM-dd"),
           nextBillingDate: calculateNextBillingDateFromStart(new Date(), new Date(), "monthly"),
@@ -112,7 +113,7 @@ export function SubscriptionForm({
       setErrors({})
       setNextDateTouched(false)
     }
-  }, [open, initialData])
+  }, [open, initialData, userCurrency])
 
   // Handle basic input changes
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {

--- a/src/services/exchangeRateApi.ts
+++ b/src/services/exchangeRateApi.ts
@@ -21,6 +21,7 @@ export interface ExchangeRateConfigStatus {
   tianApiConfigured: boolean;
   provider: string;
   updateFrequency: string;
+  baseCurrency?: string;
 }
 
 /**

--- a/src/services/exchangeRateApi.ts
+++ b/src/services/exchangeRateApi.ts
@@ -92,18 +92,35 @@ export class ExchangeRateApi {
    */
   static ratesToMap(rates: ExchangeRate[]): Record<string, number> {
     const rateMap: Record<string, number> = {};
-    const baseCurrency = getBaseCurrency();
 
+    if (!rates || rates.length === 0) {
+      // Fallback to frontend base currency with self rate
+      rateMap[getBaseCurrency()] = 1;
+      return rateMap;
+    }
+
+    // Prefer the entry that represents base -> base with rate 1
+    const selfRate = rates.find(r => r.from_currency === r.to_currency && Math.abs(r.rate - 1) < 1e-9);
+    let serverBase = selfRate?.from_currency;
+
+    // If not present, infer the most common from_currency; fallback to first
+    if (!serverBase) {
+      const countMap = new Map<string, number>();
+      for (const r of rates) {
+        countMap.set(r.from_currency, (countMap.get(r.from_currency) || 0) + 1);
+      }
+      serverBase = Array.from(countMap.entries()).sort((a, b) => b[1] - a[1])[0]?.[0] || rates[0].from_currency;
+    }
+
+    // Build mapping from the server-declared base currency
     for (const rate of rates) {
-      // 使用 from_currency 作为键，rate 作为值
-      // 这样可以直接查找从基础货币到其他货币的汇率
-      if (rate.from_currency === baseCurrency) {
+      if (rate.from_currency === serverBase) {
         rateMap[rate.to_currency] = rate.rate;
       }
     }
 
-    // 确保基础货币到自身的汇率为 1
-    rateMap[baseCurrency] = 1;
+    // Ensure base currency self rate exists
+    rateMap[serverBase] = 1;
 
     return rateMap;
   }


### PR DESCRIPTION
Align default currency in subscription and payment forms with user settings and derive base currency for analytics and exchange rates from API data.

This fixes a bug where subscription forms did not respect the user's display currency from settings. It also standardizes currency handling by ensuring frontend forms use user preferences and backend-related calculations use the authoritative base currency provided by the API, preventing mismatches with `.env` or fixed constants.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d1b880b-6eef-413f-bccc-9ef48abf8669">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2d1b880b-6eef-413f-bccc-9ef48abf8669">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

